### PR TITLE
link pthread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 speedtest_cli: main.c
-	gcc $< -lcurl -lexpat -lm -o $@
+	gcc $< -lpthread -lcurl -lexpat -lm -o $@
 
 clean:
 	rm speedtest_cli


### PR DESCRIPTION
.. got 
```
root@1:/temp/speedtest-cli# make
gcc main.c -lcurl -lexpat -lm -o speedtest_cli
/usr/bin/ld: /tmp/ccFx2G2W.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:2: recipe for target 'speedtest_cli' failed
make: *** [speedtest_cli] Error 1
```
fixes #4 