### PR TITLE
no need to lie on the user-agent

### DIFF
--- a/main.c
+++ b/main.c
@@ -656,7 +656,7 @@ static int get_client_info(struct client_info *p_client)
     curl_easy_setopt(curl, CURLOPT_URL, "http://www.speedtest.net/speedtest-config.php");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_web_buf);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &web);
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows NT 6.2; rv:22.0) Gecko/20130405 Firefox/22.0");
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "haibbo speedtest-cli");
     //curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);


### PR DESCRIPTION
as far as i know, they do not use an user-agent white-list anyway, so there's no need to lie.

and testing it:
```
$ curl -L --user-agent "haibbo speedtest-cli" --verbose http://www.speedtest.net/speedtest-config.php
*   Trying 151.101.2.219...
* TCP_NODELAY set
* Connected to www.speedtest.net (151.101.2.219) port 80 (#0)
> GET /speedtest-config.php HTTP/1.1
> Host: www.speedtest.net
> User-Agent: haibbo speedtest-cli
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Retry-After: 0
< Content-Length: 0
< Location: https://www.speedtest.net/speedtest-config.php
< Date: Wed, 29 May 2019 11:45:27 GMT
< Connection: close
< Accept-Ranges: bytes
<
* Closing connection 0
* Issue another request to this URL: 'https://www.speedtest.net/speedtest-config.php'
*   Trying 151.101.2.219...
* TCP_NODELAY set
* Connected to www.speedtest.net (151.101.2.219) port 443 (#1)
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
* TLSv1.2 (OUT), TLS header, Certificate Status (22):
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: C=US; ST=Washington; L=Seattle; O=Ookla LLC; CN=www.speedtest.net
*  start date: Mar 25 21:11:14 2019 GMT
*  expire date: Nov  6 19:17:50 2019 GMT
*  subjectAltName: host "www.speedtest.net" matched cert's "www.speedtest.net"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign CloudSSL CA - SHA256 - G3
*  SSL certificate verify ok.
> GET /speedtest-config.php HTTP/1.1
> Host: www.speedtest.net
> User-Agent: haibbo speedtest-cli
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/xml
< Content-Length: 13642
< Date: Wed, 29 May 2019 11:45:27 GMT
< Connection: keep-alive
< Accept-Ranges: bytes
< Vary: Accept-Encoding
<
<?xml version="1.0" encoding="UTF-8"?>
<settings>
<client ip="85.164.164.153" lat="59.2675" lon="10.4076" isp="Telenor Norge AS" isprating="3.7" rating="0" ispdlavg="0" ispulavg="0" loggedin="0" country="NO" />
<server-config threadcount="4" ignoreids="1525,1716,1758,1762,1816,1834,1839,1840,1850,1854,1859,1860,1861,1871,1873,1875,1880,1902,1913,3280,3448,3695,3696,3

<capped>
```